### PR TITLE
🔀 :: 회원가입시에 학생과 선생님 구별하여 권한 부여하기

### DIFF
--- a/src/main/java/com/mindway/server/v2/domain/auth/exception/UserNotFoundException.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/exception/UserNotFoundException.java
@@ -3,9 +3,9 @@ package com.mindway.server.v2.domain.auth.exception;
 import com.mindway.server.v2.global.exception.ErrorCode;
 import com.mindway.server.v2.global.exception.MindWayException;
 
-public class MemberNotFoundException extends MindWayException {
+public class UserNotFoundException extends MindWayException {
 
-    public MemberNotFoundException() {
+    public UserNotFoundException() {
         super(ErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/main/java/com/mindway/server/v2/domain/auth/service/impl/ReissueTokenServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/service/impl/ReissueTokenServiceImpl.java
@@ -2,7 +2,7 @@ package com.mindway.server.v2.domain.auth.service.impl;
 
 import com.mindway.server.v2.domain.auth.RefreshToken;
 import com.mindway.server.v2.domain.auth.exception.ExpiredRefreshTokenException;
-import com.mindway.server.v2.domain.auth.exception.MemberNotFoundException;
+import com.mindway.server.v2.domain.auth.exception.UserNotFoundException;
 import com.mindway.server.v2.domain.auth.presentation.dto.response.TokenResponse;
 import com.mindway.server.v2.domain.auth.repository.RefreshRepository;
 import com.mindway.server.v2.domain.auth.service.ReissueTokenService;
@@ -27,7 +27,7 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
                 .orElseThrow(ExpiredRefreshTokenException::new);
 
         User user = userRepository.findById(refreshEntity.getMemberId())
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         refreshRepository.deleteById(refreshEntity.getRefreshToken());
 

--- a/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mindway.server.v2.domain.auth.service.impl;
 
 import com.mindway.server.v2.domain.auth.RefreshToken;
+import com.mindway.server.v2.domain.auth.exception.UserNotFoundException;
 import com.mindway.server.v2.domain.auth.presentation.dto.request.SignInRequest;
 import com.mindway.server.v2.domain.auth.presentation.dto.response.TokenResponse;
 import com.mindway.server.v2.domain.auth.repository.RefreshRepository;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -52,6 +54,9 @@ public class SignInServiceImpl implements SignInService {
             User user = userRepository.findByEmail(userInfo.getEmail())
                     .orElseGet(() -> saveUser(userInfo));
 
+            if (user == null)
+                throw new UserNotFoundException();
+
             TokenResponse tokenResponse = jwtProvider.generateTokenDto(user.getId());
 
             saveRefreshToken(tokenResponse, user);
@@ -82,7 +87,6 @@ public class SignInServiceImpl implements SignInService {
                 .email(gAuthUserInfo.getEmail())
                 .name(gAuthUserInfo.getName())
                 .studentNum(new StudentNum(gAuthUserInfo.getGrade(), gAuthUserInfo.getClassNum(), gAuthUserInfo.getNum()))
-                .gauth_role(gAuthUserInfo.getRole())
                 .authority(Authority.ROLE_STUDENT)
                 .build();
 

--- a/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
@@ -68,6 +68,15 @@ public class SignInServiceImpl implements SignInService {
     }
 
     private User saveUser(GAuthUserInfo gAuthUserInfo) {
+        if (Objects.equals(gAuthUserInfo.getRole(), "ROLE_STUDENT")) {
+            return saveStudent(gAuthUserInfo);
+        } else if (Objects.equals(gAuthUserInfo.getRole(), "ROLE_TEACHER")) {
+            return saveTeacher(gAuthUserInfo);
+        }
+        return null;
+    }
+
+    private User saveStudent(GAuthUserInfo gAuthUserInfo) {
         User user = User.builder()
                 .id(UUID.randomUUID())
                 .email(gAuthUserInfo.getEmail())

--- a/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/service/impl/SignInServiceImpl.java
@@ -91,6 +91,20 @@ public class SignInServiceImpl implements SignInService {
         return user;
     }
 
+    private User saveTeacher(GAuthUserInfo gAuthUserInfo) {
+        User teacher = User.builder()
+                .id(UUID.randomUUID())
+                .email(gAuthUserInfo.getEmail())
+                .name(gAuthUserInfo.getName())
+                .studentNum(new StudentNum(gAuthUserInfo.getGrade(), gAuthUserInfo.getClassNum(), gAuthUserInfo.getNum()))
+                .authority(Authority.ROLE_TEACHER)
+                .build();
+
+        userRepository.save(teacher);
+
+        return teacher;
+    }
+
     private void saveRefreshToken(TokenResponse tokenResponse, User user) {
         RefreshToken refreshToken = RefreshToken.builder()
                 .refreshToken(tokenResponse.getRefreshToken())

--- a/src/main/java/com/mindway/server/v2/domain/user/entity/User.java
+++ b/src/main/java/com/mindway/server/v2/domain/user/entity/User.java
@@ -26,8 +26,6 @@ public class User {
     @Embedded
     private StudentNum studentNum;
 
-    private String gauth_role;
-
     @Enumerated(EnumType.STRING)
     private Authority authority;
 

--- a/src/main/java/com/mindway/server/v2/domain/user/util/UserUtil.java
+++ b/src/main/java/com/mindway/server/v2/domain/user/util/UserUtil.java
@@ -1,6 +1,6 @@
 package com.mindway.server.v2.domain.user.util;
 
-import com.mindway.server.v2.domain.auth.exception.MemberNotFoundException;
+import com.mindway.server.v2.domain.auth.exception.UserNotFoundException;
 import com.mindway.server.v2.domain.user.entity.User;
 import com.mindway.server.v2.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,6 @@ public class UserUtil {
     public User getCurrentUser() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         return userRepository.findByEmail(email)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
     }
 }


### PR DESCRIPTION
## 💡 개요
회원가입을 할때 학생과 선생님의 권한을 구별하여 권한을 부여하였습니다.
## 📃 작업내용
* User에 gauth_role 컬럼 삭제
* MemberNotFound -> UserNotFound로 변경
* saveTeacher 메서드 추가
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타