### PR TITLE
🔀 :: signIn endpoint 삭제

### DIFF
--- a/src/main/java/com/mindway/server/v2/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/mindway/server/v2/domain/auth/presentation/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
     private final ReissueTokenService reissueTokenService;
     private final LogoutService logoutService;
 
-    @PostMapping("/signin")
+    @PostMapping
     public ResponseEntity<TokenResponse> signIn(@RequestBody @Valid SignInRequest signInRequest) {
         TokenResponse response = signInService.execute(signInRequest);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 
                                 // auth
-                                .requestMatchers(HttpMethod.POST, "/api/v2/auth/signin").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/v2/auth").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/api/v2/auth").permitAll()
                                 .requestMatchers(HttpMethod.DELETE, "/api/v2/auth").permitAll()
 

--- a/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.PATCH, "/api/v2/recommend/{rec_id}").hasAnyAuthority(Authority.ROLE_TEACHER.name(), Authority.ROLE_HELPER.name())
                                 .requestMatchers(HttpMethod.GET, "/api/v2/recommend").authenticated()
 
-                                .anyRequest().authenticated()
+                                .anyRequest().denyAll()
                 )
 
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 💡 개요
회원가입 및 로그인의 불필요한 엔드포인트를 삭제하였습니다.
## 📃 작업내용
* signIn endpoint 변경
* security config 등록된 url이 아니면 모두 거부로 변경
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타