### PR TITLE
book list 반활될때 500 해결

### DIFF
--- a/src/main/java/com/mindway/server/v2/domain/book/service/impl/GetBookListServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/book/service/impl/GetBookListServiceImpl.java
@@ -25,10 +25,6 @@ public class GetBookListServiceImpl implements GetBookListService {
         User user = userUtil.getCurrentUser();
         List<Book> books = bookRepository.findAllByUser(user);
 
-        if (user != books.get(0).getUser()) {
-            throw new NotSameAuthorException();
-        }
-
         return books.stream()
                 .map(bookConverter::toListDto)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 💡 개요
book list을 반환할때 빈 배열일 경우 500이 뜸

## 📃 작업내용
- book list을 반환할때 빈 배열일 경우 500이 떠서 배열의 인덱스을 추줄해 보인 확인하는 로직 삭제

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타