### PR TITLE
🔀 :: 이벤트 삭제 로직에 이미지 삭제 추가

### DIFF
--- a/src/main/java/com/mindway/server/v2/domain/event/service/impl/EventDeleteServiceImpl.java
+++ b/src/main/java/com/mindway/server/v2/domain/event/service/impl/EventDeleteServiceImpl.java
@@ -1,5 +1,7 @@
 package com.mindway.server.v2.domain.event.service.impl;
 
+import com.mindway.server.v2.domain.event.entity.Event;
+import com.mindway.server.v2.domain.event.exception.NotFoundEventException;
 import com.mindway.server.v2.domain.event.repository.EventRepository;
 import com.mindway.server.v2.domain.event.service.EventDeleteService;
 import com.mindway.server.v2.domain.notice.exception.NotAccessStudentException;
@@ -7,6 +9,7 @@ import com.mindway.server.v2.domain.user.entity.Authority;
 import com.mindway.server.v2.domain.user.entity.User;
 import com.mindway.server.v2.domain.user.util.UserUtil;
 import com.mindway.server.v2.global.annotation.ServiceWithTransaction;
+import com.mindway.server.v2.global.thirdparty.aws.S3Util;
 import lombok.RequiredArgsConstructor;
 
 @ServiceWithTransaction
@@ -15,12 +18,18 @@ public class EventDeleteServiceImpl implements EventDeleteService {
 
     private final EventRepository eventRepository;
     private final UserUtil userUtil;
+    private final S3Util s3Util;
 
     public void execute(Long id) {
         User user = userUtil.getCurrentUser();
 
         if (user.getAuthority() == Authority.ROLE_STUDENT)
             throw new NotAccessStudentException();
+
+        Event event = eventRepository.findById(id)
+                .orElseThrow(NotFoundEventException::new);
+
+        s3Util.deleteImage(event.getImg_url());
 
         eventRepository.deleteById(id);
     }

--- a/src/main/java/com/mindway/server/v2/domain/image/presentation/ImageController.java
+++ b/src/main/java/com/mindway/server/v2/domain/image/presentation/ImageController.java
@@ -5,12 +5,14 @@ import com.mindway.server.v2.domain.image.service.ImageUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v2/image")
 public class ImageController {
 
     private final ImageUploadService imageUploadService;

--- a/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/mindway/server/v2/global/security/config/SecurityConfig.java
@@ -96,6 +96,9 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.DELETE, "/api/v2/recommend/{rec_id}").hasAnyAuthority(Authority.ROLE_TEACHER.name(), Authority.ROLE_HELPER.name())
                                 .requestMatchers(HttpMethod.GET, "/api/v2/recommend").authenticated()
 
+                                // image
+                                .requestMatchers(HttpMethod.POST, "/api/v2/image").hasAnyAuthority(Authority.ROLE_TEACHER.name(), Authority.ROLE_HELPER.name())
+
                                 .anyRequest().denyAll()
 
 

--- a/src/main/java/com/mindway/server/v2/global/thirdparty/aws/S3Util.java
+++ b/src/main/java/com/mindway/server/v2/global/thirdparty/aws/S3Util.java
@@ -49,4 +49,9 @@ public class S3Util {
         amazonS3.putObject(bucket, profileName, file.getInputStream(), metadata);
         return amazonS3.getUrl(bucket, profileName).toString();
     }
+
+    public void deleteImage(String url) {
+        String key = url.split("com/")[1];
+        amazonS3.deleteObject(bucket, key);
+    }
 }


### PR DESCRIPTION
## 💡 개요
이벤트를 삭제할 때 이벤트에 등록되어있는 이미지를 삭제하는 로직이 없어 추가하였습니다.
## 📃 작업내용
* 이벤트 삭제 로직에 이미지 삭제 로직 추가
* S3Util에 이미지 삭제 메서드 추가
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타